### PR TITLE
python3: adjust pathname2url

### DIFF
--- a/src/SudsLibrary/clientmanagement.py
+++ b/src/SudsLibrary/clientmanagement.py
@@ -115,5 +115,5 @@ class _ClientManagementKeywords(object):
         if not len(urlparse(url_or_path).scheme) > 1:
             if not os.path.isfile(url_or_path):
                 raise IOError("File '%s' not found." % url_or_path)
-            url_or_path = 'file:' + urllib.pathname2url(url_or_path)
+            url_or_path = 'file:' + urllib.request.pathname2url(url_or_path)
         return url_or_path


### PR DESCRIPTION
As described in [1], the pathname2url function has been moved.

[1] https://docs.python.org/3/library/urllib.request.html#urllib.request.pathname2url